### PR TITLE
Add a Netz39 logo variant

### DIFF
--- a/assets/logo/netz39_logo_2013-07-11.png
+++ b/assets/logo/netz39_logo_2013-07-11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f4323bbdbfac507504611ec8e677008bcc57c9c83778dfdd8b8f13bfd82c7b7
+size 16630


### PR DESCRIPTION
This PR adds a Netz39 logo variant.

This is mainly intended as a starter for LFS objects (see https://github.com/git-lfs/git-lfs/issues/1449),