### PR TITLE
add more image file types to lfs filter

### DIFF
--- a/assets/.gitattributes
+++ b/assets/.gitattributes
@@ -1,5 +1,7 @@
+**/*.jpeg filter=lfs diff=lfs merge=lfs -text
 **/*.jpg filter=lfs diff=lfs merge=lfs -text
 **/*.png filter=lfs diff=lfs merge=lfs -text
+**/*.svg filter=lfs diff=lfs merge=lfs -text
 **/*.gif filter=lfs diff=lfs merge=lfs -text
 **/*.mp4 filter=lfs diff=lfs merge=lfs -text
 **/*.mp3 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This pull request includes updates to the `.gitattributes` file to ensure proper handling of additional image file types by Git LFS (Large File Storage).

File type handling updates:

* [`assets/.gitattributes`](diffhunk://#diff-b90ce55b9a01541d55003cb166a94107927504cf3dc44af02ca0d9713cf76c66R1-R4): Added LFS handling for `*.jpeg` and `*.svg` files.