### PR TITLE
assets: img: post: Add picture for OpenStreetMap Magdeburg

### DIFF
--- a/assets/img/post-img/2026/2026-05-11-openstreetmap-stammtisch/osm-magdeburg.png
+++ b/assets/img/post-img/2026/2026-05-11-openstreetmap-stammtisch/osm-magdeburg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:020612cd46bac5bad648e751f29f70f6ce827f7cc8214526d1c9074f476daae2
+size 298156


### PR DESCRIPTION
Screenshot from the OSM Wiki with OSM Logo on top. License CC-BY-SA 3.0, original OSM Logo by Ken Vermette.

Link: https://wiki.openstreetmap.org/wiki/Magdeburg
Link: https://wiki.openstreetmap.org/wiki/File:Public-images-osm_logo.svg